### PR TITLE
0.4.1 see Changelog.md.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+## 0.4.1 - *9/22/2015*
+
+- Support systems where uuidgen creates lowercase UUIDs
+
 ## 0.4.0 - *9/22/2015*
 
 - Renamed the `destroy` command to `drop`.

--- a/jsonlite.sh
+++ b/jsonlite.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-VERSION="0.4.0"
+VERSION="0.4.1"
 COMMAND=$1
 CWD=$(pwd);
 
@@ -27,7 +27,7 @@ case "$COMMAND" in
         fi
 
         # Is this portable across distros?
-        UUID=$(uuidgen)
+        UUID=$(uuidgen | awk '{print toupper($0)}')
 
         # Piping to python -m json.tool to pretty print json is super expensive.
         # What would be a good alternative?


### PR DESCRIPTION
On Fedora20, uuidgen seems to create lowercase UUIDs.

e.g.

``` bash
$ uuidgen
b510981e-2b6b-4444-ab06-ba798f8dca86
```
